### PR TITLE
Fix parameters

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -23,8 +23,8 @@ local secret = kube.Secret('maxscale') {
   },
   // Secrets are assumed to be Vault refs
   stringData: {
-    service_pwd: params.maxscale.service_pwd,
-    monitor_pwd: params.maxscale.monitor_pwd,
+    service_pwd: params.service_pwd,
+    monitor_pwd: params.monitor_pwd,
   },
 };
 
@@ -58,18 +58,18 @@ local deployment = kube.Deployment('maxscale') {
             image: params.images.maxscale.image + ':' + params.images.maxscale.tag
             ,
             env_+: std.prune(com.proxyVars {
-              MASTER_ONLY_LISTEN_ADDRESS: params.maxscale.master_only_listen_address,
-              READ_WRITE_LISTEN_ADDRESS: params.maxscale.read_write_listen_address,
-              DB1_ADDRESS: params.maxscale.db1_address,
-              DB1_PORT: params.maxscale.db1_port,
-              DB2_ADDRESS: params.maxscale.db2_address,
-              DB2_PORT: params.maxscale.db2_port,
-              DB3_ADDRESS: params.maxscale.db3_address,
-              DB3_PORT: params.maxscale.db3_port,
-              SERVICE_USER: params.maxscale.service_user,
-              SERVICE_PWD: params.maxscale.service_pwd,
-              MONITOR_USER: params.maxscale.monitor_user,
-              MONITOR_PWD: params.maxscale.monitor_pwd,
+              MASTER_ONLY_LISTEN_ADDRESS: params.master_only_listen_address,
+              READ_WRITE_LISTEN_ADDRESS: params.read_write_listen_address,
+              DB1_ADDRESS: params.db1_address,
+              DB1_PORT: params.db1_port,
+              DB2_ADDRESS: params.db2_address,
+              DB2_PORT: params.db2_port,
+              DB3_ADDRESS: params.db3_address,
+              DB3_PORT: params.db3_port,
+              SERVICE_USER: params.service_user,
+              SERVICE_PWD: params.service_pwd,
+              MONITOR_USER: params.monitor_user,
+              MONITOR_PWD: params.monitor_pwd,
             }),
             ports_+: {
               masteronly: { containerPort: 3306 },

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -4,3 +4,17 @@
 ---
 parameters:
   _instance: maxscale
+  maxscale:
+    namespace: maxscale-test
+    master_only_listen_address: 127.0.0.1
+    read_write_listen_address: 127.0.0.1
+    db1_address: db1.mygalera.test.example.org
+    db1_port: 3307
+    db2_address: db2.mygalera.test.example.org
+    db2_port: 3307
+    db3_address: db3.mygalera.test.example.org
+    db3_port: 3307
+    service_user: maxscale-testservice
+    monitor_user: maxscale-testmonitor
+    service_pwd: testservicepwd
+    monitor_pwd: testmonitorpwd


### PR DESCRIPTION
This fixes parameter output and also generates a namespace in case it doesn't exist yet.

Previously, parameters were simply ignored because the reference pointed at `params.maxscale` instead of just `params`. `params` is already scoped to `params.maxscale` so this wasn't necessary.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
