### PR TITLE
Don't care about creating a namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -18,14 +18,6 @@ local default_resources = {
 
 local resources = if res != null then std.mergePatch(default_resources, res) else null;
 
-local namespace = kube.Namespace(params.namespace) {
-  metadata+: {
-    labels+: {
-      SYNMonitoring: 'main',
-    },
-  },
-};
-
 local secret = kube.Secret('maxscale') {
   metadata+: {
     namespace: params.namespace,
@@ -166,6 +158,5 @@ local configfile = kube.ConfigMap('maxscale-config') {
 
 
 {
-  '00_namespace': namespace,
   '10_maxscale': [ secret, deployment, service_masteronly, service_rwsplit, configfile ],
 }


### PR DESCRIPTION
The component no longer cares if the namespace it's supposed to be in doesn't exist yet.

This prevents ArgoCD from complaining about multiple instances. Since MaxScale is often deployed along with other things in the same namespace, the namespace should be created separately.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
