### PR TITLE
Refer to credentials via kube.SecretKeyRef(). Fixes #23

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -73,9 +73,9 @@ local deployment = kube.Deployment('maxscale') {
               DB3_ADDRESS: params.db3_address,
               DB3_PORT: params.db3_port,
               SERVICE_USER: params.service_user,
-              SERVICE_PWD: params.service_pwd,
+              SERVICE_PWD: kube.SecretKeyRef(secret, 'service_pwd'),
               MONITOR_USER: params.monitor_user,
-              MONITOR_PWD: params.monitor_pwd,
+              MONITOR_PWD: kube.SecretKeyRef(secret, 'monitor_pwd'),
             }),
             ports_+: {
               masteronly: { containerPort: 3306 },


### PR DESCRIPTION
This refers to the existing secret instead of writing the same password into the env vars again.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
