### PR TITLE
Use Commodore 0.14+ way of specifying multi_instance

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   maxscale:
-    multi_instance: true
-    =_metadata: {}
+    =_metadata:
+      multi_instance: true
     namespace: syn-${_instance}
     master_only_listen_address: 0.0.0.0
     read_write_listen_address: 0.0.0.0


### PR DESCRIPTION
Commodore v0.14 introduced a change in how multi_instance capability is advertised. This PR updates the maxscale component to match.

See: https://syn.tools/commodore/reference/deprecation-notices.html#_v0_14_0

Merging this means the component is no longer compatible with Commodore <v0.14.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
