### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,8 +13,8 @@ parameters:
     db3_port: 3306
     service_user: maxscale
     monitor_user: maxscale
-    service_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/service_pwd}
-    monitor_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/monitor_pwd}
+    service_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/service_pwd}
+    monitor_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/monitor_pwd}
     replicas: 2
     affinity: {}
     images:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -82,13 +82,13 @@ default:: `maxscale`
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/maxscale/service_pwd}`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/maxscale/service_pwd}`
 
 == `monitor_pwd`
 
 [horizontal]
 type:: string
-default:: `?{vaultkv:${customer:name}/${cluster:name}/maxscale/monitor_pwd}`
+default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/maxscale/monitor_pwd}`
 
 = Pod Affinity Parameters
 

--- a/tests/affinity.yml
+++ b/tests/affinity.yml
@@ -27,8 +27,8 @@ parameters:
     db3_port: 3307
     service_user: maxscale-testservice
     monitor_user: maxscale-testmonitor
-    service_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/service_pwd}
-    monitor_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/monitor_pwd}
+    service_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/service_pwd}
+    monitor_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/monitor_pwd}
     resources:
       limits:
         memory: 512Mi

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -18,8 +18,8 @@ parameters:
     db3_port: 3307
     service_user: maxscale-testservice
     monitor_user: maxscale-testmonitor
-    service_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/service_pwd}
-    monitor_pwd: ?{vaultkv:${customer:name}/${cluster:name}/${_instance}/monitor_pwd}
+    service_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/service_pwd}
+    monitor_pwd: ?{vaultkv:${cluster:tenant}/${cluster:name}/${_instance}/monitor_pwd}
     resources:
       limits:
         memory: 512Mi


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
